### PR TITLE
add method "rsample" for distribution normal

### DIFF
--- a/src/normal.rs
+++ b/src/normal.rs
@@ -1,4 +1,4 @@
-use crate::{Distribution, KullackLeiberDivergence};
+use crate::{utils::standard_normal, Distribution, KullackLeiberDivergence};
 use std::f64::consts::PI;
 use tch::Tensor;
 
@@ -39,6 +39,13 @@ impl Normal {
     /// Returns the standard deviation of the distribution.
     pub fn stddev(&self) -> &Tensor {
         &self.stddev
+    }
+
+    /// Returns sample(s) by using reparameterization trick
+    pub fn rsample(&self, shape: &[i64]) -> Tensor {
+        let shape = self.extended_shape(shape);
+        let eps = standard_normal(&shape, self.mean.kind(), self.mean.device());
+        &self.mean + eps * &self.stddev
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,3 +49,7 @@ pub fn infinity(kind: Kind) -> Tensor {
         k => panic!("{:?} cannot represent infinity", k),
     }
 }
+
+pub fn standard_normal(shape: &[i64], dtype: tch::Kind, device: tch::Device) -> Tensor {
+    Tensor::empty(shape, (dtype, device)).normal_(0., 1.)
+}


### PR DESCRIPTION
For distribution "Normal", I add a method called `rsample`, just like the method in `pytorch`, which is useful when tracking gradient of distribution "Normal".
And to complete `rsample`, a function called `standard_normal` is added to file `utils.rs`.
Finally, for testing, I add a function called `test_rsample_of_normal_distribution`.