### PR TITLE
fix test_sample and method of some distributions --- "MultivariateNormal","Bernoulli" and "Uniform"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub trait Distribution {
 
     /// Generates a sample_shape shaped sample or sample_shape shaped batch of
     /// samples if the distribution parameters are batched.
-    fn sample(&self, shape: &[i64]) -> Tensor;
+    fn sample(&self, _shape: &[i64]) -> Tensor {
+        unimplemented!()
+    }
 
     #[doc(hidden)]
     fn batch_shape(&self) -> &[i64] {


### PR DESCRIPTION
1. For distribution "MultivariateNormal","bernoulli" and "uniform", fixed (invalid) and enriched test samples for each distribution.
2. For distribution "MultivariateNormal", add method `rsample`, and delete method `sample`.
3. For distribution "MultivariateNormal", fix the method `precision_to_scale_tril` and the parsed parameter when initilazing with "precision".
4. set method `sample` of trait `Distribution` as "unimplemented!()", because some distribution does not have method `sample`, like "MultivariateNormal".


After this pull request, all test should be passed.