### PR TITLE
Fix a categorical distribution bug

### DIFF
--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -56,7 +56,7 @@ impl Categorical {
         let logits = logits - logsumexp;
 
         let batch_shape: Vec<i64> = if logits.size().len() > 1 {
-            vec![logits.size().last().unwrap().clone()]
+            logits.size().split_last().unwrap().1.to_vec()
         } else {
             vec![]
         };

--- a/tests/against_python.rs
+++ b/tests/against_python.rs
@@ -83,24 +83,35 @@ fn tensor_to_py_obj<'py>(py_env: &'py PyEnv, t: &Tensor) -> &'py PyAny {
 fn assert_tensor_eq<'py>(py: Python<'py>, t: &Tensor, py_t: &PyAny) {
     // transfter type to f64(Double)
     let python_side_array: &PyArrayDyn<f64> = if t.kind() == tch::Kind::Int64 {
-        let tmp_pyarray: &PyArrayDyn<i64> = py_t.call_method0("numpy").unwrap().extract().unwrap();
+        let tmp_pyarray: &PyArrayDyn<i64> = py_t
+            .call_method0("contiguous")
+            .unwrap()
+            .call_method0("numpy")
+            .unwrap()
+            .extract()
+            .unwrap();
         tmp_pyarray
             .call_method1("astype", ("float64",))
             .unwrap()
             .extract()
             .unwrap()
     } else {
-        py_t.call_method0("numpy").unwrap().extract().unwrap()
+        py_t.call_method0("contiguous")
+            .unwrap()
+            .call_method0("numpy")
+            .unwrap()
+            .extract()
+            .unwrap()
     };
 
     // TODO: how to treat NaN as same?
-    
+
     // let tmp_rust_side_array = &t.to_kind(tch::Kind::Float);
     let rust_side_array: ArrayD<f64> = t.try_into().unwrap();
     let rust_side_array: &PyArrayDyn<f64> = rust_side_array.to_pyarray(py); ////or default type:&PyArrayDyn<f64,Dim<IxDynImpl>>
-    // println!("rust pyarray1:{}", rust_side_array);
-    // println!("python pyarray1:{}", python_side_array); // type:&PyArrayDyn<f64>
-    // println!("===========1===========\n");
+    println!("rust pyarray1:{}", rust_side_array);
+    println!("python pyarray1:{}", python_side_array); // type:&PyArrayDyn<f64>
+    println!("===========1===========\n");
 
     let python_side_array = python_side_array.as_cell_slice().unwrap();
     let rust_side_array = rust_side_array.as_cell_slice().unwrap();
@@ -240,6 +251,14 @@ fn normal() {
         (1.0.into(), 2.0.into()),
         (2.0.into(), 4.0.into()),
         (Tensor::of_slice(&[1.0, 1.0]), Tensor::of_slice(&[2.0, 2.0])),
+        (
+            Tensor::try_from(array![[1.0], [1.0]]).unwrap(),
+            Tensor::try_from(array![[2.0], [2.0]]).unwrap(),
+        ),
+        (
+            Tensor::try_from(array![[1.0, 0.5], [1.0, 2.0]]).unwrap(),
+            Tensor::try_from(array![[2.0, 1.0], [2.0, 1.0]]).unwrap(),
+        ),
     ];
 
     let mut test_cases = TestCases::default();
@@ -475,7 +494,6 @@ fn poisson() {
             .getattr("Poisson")
             .expect("call Poisson failed")
             .call1((tensor_to_py_obj(&py_env, &rate),))
-            // .call1("Poisson", (tensor_to_py_obj(&py_env, &rate),))
             .unwrap();
         let dist_rs = Poisson::new(rate);
         run_test_cases(&py_env, dist_rs, dist_py, &test_cases);
@@ -866,10 +884,14 @@ fn categorical() {
 
     // 1.init/test with probabilities
     let prob_args_vec: Vec<Tensor> = vec![
-        Tensor::of_slice(&[0.4, 0.3, 0.3]),
         Tensor::of_slice(&[0.25, 0.25, 0.1, 0.4]),
         Tensor::try_from(array![[0.1, 0.1, 0.8], [0.1, 0.7, 0.2], [0.3, 0.4, 0.3]])
             .expect("initial from array failed"),
+        Tensor::try_from(array![
+            [[0.4, 0.4, 0.2], [0.7, 0.2, 0.1], [0.7, 0.2, 0.1]],
+            [[0.3, 0.6, 0.1], [0.4, 0.1, 0.5], [0.7, 0.2, 0.1]]
+        ])
+        .expect("initial from array failed"),
     ];
 
     let mut test_cases = TestCases::default();
@@ -878,11 +900,11 @@ fn categorical() {
     test_cases.log_prob = Some(vec![
         1.0.into(),
         2.0.into(),
-        // the below is invalid paramters for multi-dim initialed categorical ditribution
-        // Tensor::of_slice(&[1.0, 1.0]),
-        // Tensor::of_slice(&[2.0, 2.0]),
+        Tensor::try_from(array![[1.0], [1.0]]).unwrap(),
+        Tensor::try_from(array![[1, 0, 2], [0, 1, 2]]).unwrap(),
+        // Tensor::of_slice(&[2.0, 2.0]),//invalid paramters
     ]);
-    test_cases.sample = None; //Some(vec![vec![1], vec![3]]);
+    test_cases.sample = Some(vec![vec![1], vec![3]]);
     for probs in prob_args_vec.into_iter() {
         let dist_py = py_env
             .distributions
@@ -910,10 +932,14 @@ fn categorical() {
 
     // 2.init/test with log probabilities
     let log_args_vec: Vec<Tensor> = vec![
-        Tensor::of_slice(&[0.4, 0.3, 0.3]),
         Tensor::of_slice(&[0.25, 0.25, 0.1, 0.4]),
         Tensor::try_from(array![[0.1, 0.1, 0.8], [0.1, 0.7, 0.2], [0.3, 0.4, 0.3]])
             .expect("initial from array failed"),
+        Tensor::try_from(array![
+            [[0.4, 0.4, 0.2], [0.7, 0.2, 0.1], [0.7, 0.2, 0.1]],
+            [[0.3, 0.6, 0.1], [0.4, 0.1, 0.5], [0.7, 0.2, 0.1]]
+        ])
+        .expect("initial from array failed"),
     ];
 
     let mut test_cases = TestCases::default();
@@ -922,11 +948,11 @@ fn categorical() {
     test_cases.log_prob = Some(vec![
         1.0.into(),
         2.0.into(),
-        // the below is invalid paramters for multi-dim initialed categorical ditribution
-        // Tensor::of_slice(&[1.0, 1.0]),
-        // Tensor::of_slice(&[2.0, 2.0]),
+        Tensor::try_from(array![[1.0], [1.0]]).unwrap(),
+        Tensor::try_from(array![[1, 0, 2], [0, 1, 2]]).unwrap(),
+        // Tensor::of_slice(&[2.0, 2.0]),//invalid paramters
     ]);
-    test_cases.sample = None; //Some(vec![vec![1], vec![3]]);
+    test_cases.sample = Some(vec![vec![1], vec![3]]);
     for logits in log_args_vec.into_iter() {
         let dist_py = py_env
             .distributions


### PR DESCRIPTION
1.Fix a categorical distribution bug which occurs when initializing `from_logit`;
2.Enrich some test samples;
3.For function `assert_tensor_eq`, the array from python is forced to be `contiguous` before comparision, related issue:https://github.com/PyO3/rust-numpy/issues/203#issuecomment-924501497

Besides, for the error occurs when testing distribution `poisson`, I can't figure it out yet--- sometimes it is passed, sometimes not.